### PR TITLE
Add build script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ Cada aporte queda registrado en el historial de **commits** y la actividad en **
 lo que servirá para reconocer a quienes colaboren. Consulta
 [COLABORACION.md](COLABORACION.md) para conocer las pautas completas.
 
+## 🛠️ Compilación del libro
+
+El script `build.sh` genera un único archivo a partir de todos los documentos Markdown usando [pandoc](https://pandoc.org/). Por defecto produce `libro.pdf`, pero se puede indicar un nombre diferente (por ejemplo, con extensión `.html`).
+
+```bash
+./build.sh            # genera libro.pdf
+./build.sh libro.html # genera HTML
+```
+
+Necesitas tener `pandoc` instalado para que la conversión funcione.
+
 -----
 
 ## 🔒 LICENCIA

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Combina todos los archivos Markdown del repositorio en un solo documento.
+# Uso: ./build.sh [salida]
+# Si no se especifica [salida], se generará 'libro.pdf'.
+
+set -e
+
+OUTPUT=${1:-libro.pdf}
+
+# Encontrar todos los archivos .md y ordenarlos alfabéticamente
+FILES=$(find . -name "*.md" | sort)
+
+pandoc $FILES -s -o "$OUTPUT"
+
+echo "Documento generado: $OUTPUT"
+


### PR DESCRIPTION
## Summary
- add `build.sh` to combine all Markdown files with pandoc
- document how to generate the book in README

## Testing
- `./build.sh libro.html`
- `./build.sh` *(fails: pdflatex not found)*

------
https://chatgpt.com/codex/tasks/task_b_684499070da48322a4ce37fc930fab1e