### PR TITLE
Add English README with cross-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # LIBERANDO AL THETAN
+*English version available in [README_EN.md](README_EN.md).* 
 
 ## Las enseñanzas de la Cienciología: arqueología simbólica de un sistema de control
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,146 @@
+# RELEASING THE THETAN
+*Versión en español disponible en [README.md](README.md).*
+
+## The Teachings of Scientology: Symbolic Archaeology of a Control System
+
+*A manual of soul reverse engineering for post-cult reconfiguration*
+
+-----
+
+## ✴️ MANIFESTO
+
+This is not a book of denouncement. Nor is it an academic essay.
+It is an **act of symbolic and political liberation**, a **liturgy of disarmament**.
+
+Here we dare to look at a feared system—Scientology—not just to expose it but to understand **what part of ourselves found refuge in it**.
+
+This is a **lucid exorcism**, a surgical operation of the soul that separates:
+
+- the symbol from the dogma,
+- the ritual from manipulation,
+- the genuine desire for healing from the apparatus that hijacks it.
+
+**The thesis is simple and radical**: even the most harmful systems work because they hijack legitimate impulses. We are not going to save Scientology. We are going to **rescue what it locked away, what it distorted, what we can reclaim as ours**.
+
+This book is a mirror for those who have passed through closed systems—religious, therapeutic, ideological, or familial—and still feel that **something there touched something real**.
+
+**It is not power that fascinates us. It is the distance between what we are and what we could be.** Scientology promises to close that gap, to turn the limited human into an unlimited Operating Thetan. But true liberation is not in transcending the human condition, but in **inhabiting it creatively**.
+
+-----
+
+## 🎧 TONE AND PERSPECTIVE
+
+**Voice**: embodied, critical, compassionate. We write from **the thinking wound**, not from the academic tower or the vengeful pulpit. It is the perspective of someone who has felt the symbolic pull of these systems without being devoured by them.
+
+**Tone**: a mix of philosophical essay, intimate confession, symbolic ritual and cultural archaeology. **Poetic rigor**: deep yet accessible, critical but not destructive.
+
+**Ethics**: fierce criticism of control, absolute respect for the symbol, and unwavering commitment to psychic freedom. **We do not promise salvation; we offer reconfiguration tools.**
+
+**Narrative position**: the voice of someone who **was never inside but understood the spell**. From studied fascination, not from direct testimony. This allows greater analytical objectivity without losing empathic warmth.
+
+-----
+
+## 🗭️ ARCHITECTURAL STRUCTURE
+
+### ✴️ PROLOGUE: “The Monster as Promise”
+
+*A ritual entry*
+
+> And... if we could all fly, be super strong, and shoot rays from our eyes... how many Superman comics would be read?
+> Probably none.
+
+[The rest of the prologue and Parts I, II and III remain just as you presented them: intact, structured, with precise titles and descriptions. Continue with Part I here if you want to follow the full document, or use this README.md as a general entry point.]
+
+-----
+
+## 📚 APPENDICES
+
+### A. Transmuted Glossary
+
+**Comparison of Scientology terms reimagined in a symbolic and therapeutic key**
+
+- Thetan → Narrative multiplicity of the self
+- Engrama → Embedded personal mythology
+- Clear → Fluid state of self-awareness
+- Auditing → Transformative ritual listening
+- Operating Thetan → Embodied conscious agency
+
+### B. Practice Laboratory
+
+**Concrete exercises for each phase of the Bridge, without dogma or closed guidance**
+
+- Internal dialogue techniques
+- Fluid biography rituals
+- Agenda-free listening practice
+- Somatic exploration methods
+
+### C. Archaeologist's Logbook
+
+**Personal fragments: moments of dissonance, humor, rupture, and revelation during deprogramming**
+
+-----
+
+## 🎯 TARGET AUDIENCE
+
+- **Former members of Scientology or other totalizing systems**
+- **Therapists, facilitators, and companions**
+- **People on a spiritual journey seeking a critical and poetic guide**
+- **Students of symbolic systems, religions, trauma, and myth**
+
+-----
+
+## 🌱 CORE VALUES
+
+1. **Critique without destruction**
+1. **Symbol without superstition**
+1. **Ritual without hierarchy**
+1. **Transformation without promise**
+1. **Freedom with poetic structure**
+
+-----
+
+## 🔥 EXPECTED IMPACT
+
+**May this book be a mirror, a tool, and a companion.**
+
+Let someone be able to say upon reading it:
+
+- *"Not everything was a lie, but it no longer controls me."*
+- *"I can reclaim the sacred without locking myself into another dogma."*
+- *"I am my own symbol. And that is enough to begin."*
+- *"The monster was my misunderstood desire. Now I can name it and release it."*
+- *"I don't need to be Superman. I need to be consciously human."*
+
+**The book as a manual of soul reverse engineering**: how to dismantle a control system, extract its useful components, and build something new, free, and fertile.
+
+**The silent revolution**: we do not promise superpowers; we promise something more radical—the beauty of being **completely, complicatedly human**.
+
+-----
+
+## 🤝 How to contribute?
+
+If you want to participate you can:
+
+- Open **issues** to propose symbols, ideas, or suggestions.
+- Send **pull requests** with new fragments, corrections, or rewritings.
+
+Each contribution is recorded in the **commit** history and activity in **issues**,
+which will serve to acknowledge those who collaborate. See
+[COLABORACION.md](COLABORACION.md) for the full guidelines.
+
+## 🛠️ Building the book
+
+The `build.sh` script generates a single file from all the Markdown documents using [pandoc](https://pandoc.org/). By default it produces `libro.pdf`, but you can specify a different name (for example, with an `.html` extension).
+
+```bash
+./build.sh            # generates libro.pdf
+./build.sh libro.html # generates HTML
+```
+
+You need to have `pandoc` installed for the conversion to work.
+
+-----
+
+## 🔒 LICENSE
+
+All contents of this repository are distributed under the [Creative Commons Attribution-ShareAlike 4.0 International License](LICENSE).


### PR DESCRIPTION
## Summary
- provide an English translation of the README as `README_EN.md`
- cross-link both README versions at the top of each file

## Testing
- `./build.sh libro.pdf` *(fails: pandoc not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68449a41c7a083228844243272fc75aa